### PR TITLE
Unblocked API on startup

### DIFF
--- a/modules/blockcreator/blockcreator.go
+++ b/modules/blockcreator/blockcreator.go
@@ -138,7 +138,7 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, w modules.Walle
 		return nil, errors.New("block creator could not save during startup: " + err.Error())
 	}
 
-	//Start the proof of block stake protocol
+	// Start the proof of block stake protocol
 	go b.SolveBlocks()
 
 	return b, nil

--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -150,6 +150,10 @@ type (
 	// A ConsensusSet accepts blocks and builds an understanding of network
 	// consensus.
 	ConsensusSet interface {
+		// Start the consensusset
+		// this function starts a new goroutine and then returns immediately
+		Start()
+
 		// AcceptBlock adds a block to consensus. An error will be returned if the
 		// block is invalid, has been seen before, is an orphan, or doesn't
 		// contribute to the heaviest fork known to the consensus set. If the block

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -342,6 +342,10 @@ type consensusSetStub struct {
 	subscribers map[modules.ConsensusSetSubscriber]struct{}
 }
 
+func (css *consensusSetStub) Start() {
+	// For testing we don't have any syncing logic
+}
+
 func (css *consensusSetStub) addTransactionAsBlock(unlockHash types.UnlockHash, value types.Currency) error {
 	l := len(css.blocks)
 	if l == 0 {


### PR DESCRIPTION
Part of issue https://github.com/threefoldfoundation/tfchain/issues/303

Added start method on:

- consensusset

And registered api endpoint before starting this module. This allow us the register the api before doing any long running tasks which are needed before starting the consensusset.