### PR TITLE
added gateway debug logging to connect / disconnect peer

### DIFF
--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -75,6 +75,7 @@ func (p *peer) accept() (modules.PeerConn, error) {
 // to handle its requests and increments the remotePeers accordingly
 func (g *Gateway) addPeer(p *peer) {
 	g.peers[p.NetAddress] = p
+	g.log.Debugln("Added peer on address", p.NetAddress)
 	go g.threadedListenPeer(p)
 }
 
@@ -729,6 +730,7 @@ func (g *Gateway) Disconnect(addr modules.NetAddress) error {
 	delete(g.nodes, addr)
 	g.mu.Unlock()
 
+	g.log.Debugln("Disconnected from peer:", addr)
 	g.log.Println("INFO: disconnected from peer", addr)
 	return nil
 }


### PR DESCRIPTION
Adds some debug logs when a peer disconnects / connects. Not sure how to reproduce issues with adding / removing peers to check if logs are sufficient.

Closes #488.