### PR TITLE
Fix #504: Require miner fees for regular txns

### DIFF
--- a/modules/consensus/diffs.go
+++ b/modules/consensus/diffs.go
@@ -156,12 +156,12 @@ func (cs *ConsensusSet) generateAndApplyDiff(tx *bolt.Tx, pb *processedBlock) er
 	// Validate and apply each transaction in the block. They cannot be
 	// validated all at once because some transactions may not be valid until
 	// previous transactions have been applied.
-	for _, txn := range pb.Block.Transactions {
+	for idx, txn := range pb.Block.Transactions {
 		err := validTransaction(tx, txn, types.TransactionValidationConstants{
 			BlockSizeLimit:         cs.chainCts.BlockSizeLimit,
 			ArbitraryDataSizeLimit: cs.chainCts.ArbitraryDataSizeLimit,
 			MinimumMinerFee:        cs.chainCts.MinimumTransactionFee,
-		}, pb.Height, pb.Block.Timestamp)
+		}, pb.Height, pb.Block.Timestamp, cs.isBlockCreatingTx(idx, pb.Block))
 		if err != nil {
 			cs.log.Printf("WARN: block %v cannot be applied: tx %v is invalid: %v",
 				pb.Block.ID(), txn.ID(), err)
@@ -199,4 +199,47 @@ func (cs *ConsensusSet) generateAndApplyDiff(tx *bolt.Tx, pb *processedBlock) er
 	}
 
 	return blockMap.Put(bid[:], siabin.Marshal(*pb))
+}
+
+// isBlockCreatingTx checks if a transaction at a given index in the block is considered to
+// be a block creating transaction within the block. A block creating transaction is a
+// transaction which respends a single blockstake output for the proof of blockstake protocol.
+// The blockstake input and output MUST be the only input and output in the transaction.
+// Furthermore, the blockstake input used in the transaction MUST spend the blockstake
+// output indicated in the POBSOutput field in the block header
+func (cs *ConsensusSet) isBlockCreatingTx(txIdx int, block types.Block) bool {
+
+	// First check if there is only 1 blockstake input and output
+
+	if len(block.Transactions[txIdx].BlockStakeInputs) != 1 {
+		return false
+	}
+
+	if len(block.Transactions[txIdx].BlockStakeOutputs) != 1 {
+		return false
+	}
+
+	if len(block.Transactions[txIdx].CoinInputs) != 0 {
+		return false
+	}
+
+	if len(block.Transactions[txIdx].CoinOutputs) != 0 {
+		return false
+	}
+
+	// this might be block creation transaction, so do a more expensive check to see
+	// if we indeed spend the output indicated in the block header
+	t, exists := cs.TransactionAtShortID(types.NewTransactionShortID(
+		block.Header().POBSOutput.BlockHeight, uint16(block.Header().POBSOutput.TransactionIndex)))
+	if !exists {
+		return false
+	}
+
+	if uint64(len(t.BlockStakeOutputs)) > block.Header().POBSOutput.OutputIndex &&
+		t.BlockStakeOutputID(block.Header().POBSOutput.OutputIndex) ==
+			block.Transactions[txIdx].BlockStakeInputs[0].ParentID {
+		return true
+	}
+
+	return false
 }

--- a/modules/consensus/validtransaction.go
+++ b/modules/consensus/validtransaction.go
@@ -59,13 +59,14 @@ func validBlockStakes(tx *bolt.Tx, t types.Transaction, blockHeight types.BlockH
 
 // validTransaction checks that all fields are valid within the current
 // consensus state. If not an error is returned.
-func validTransaction(tx *bolt.Tx, t types.Transaction, constants types.TransactionValidationConstants, blockHeight types.BlockHeight, blockTimestamp types.Timestamp) error {
+func validTransaction(tx *bolt.Tx, t types.Transaction, constants types.TransactionValidationConstants, blockHeight types.BlockHeight, blockTimestamp types.Timestamp, isBlockCreatingTx bool) error {
 	// StandaloneValid will check things like signatures and properties that
 	// should be inherent to the transaction. (storage proof rules, etc.)
 	err := t.ValidateTransaction(types.ValidationContext{
-		Confirmed:   true,
-		BlockHeight: blockHeight,
-		BlockTime:   blockTimestamp,
+		Confirmed:         true,
+		BlockHeight:       blockHeight,
+		BlockTime:         blockTimestamp,
+		IsBlockCreatingTx: isBlockCreatingTx,
 	}, constants)
 	if err != nil {
 		return err
@@ -117,11 +118,15 @@ func (cs *ConsensusSet) TryTransactionSet(txns []types.Transaction) (modules.Con
 			return err
 		}
 		for _, txn := range txns {
+			// a transaction can only be "block creating" in the context of a block,
+			// which we don't have here, so just pass in false for the "isBlockCreatingTx"
+			// argument. In other words, a block creating transaction can never be part
+			// of a transaction pool and must be inserted when the block is actually created
 			err := validTransaction(tx, txn, types.TransactionValidationConstants{
 				BlockSizeLimit:         cs.chainCts.BlockSizeLimit,
 				ArbitraryDataSizeLimit: cs.chainCts.ArbitraryDataSizeLimit,
 				MinimumMinerFee:        cs.chainCts.MinimumTransactionFee,
-			}, diffHolder.Height, blockTime)
+			}, diffHolder.Height, blockTime, false)
 			if err != nil {
 				cs.log.Printf("WARN: try-out tx %v is invalid: %v", txn.ID(), err)
 				return err

--- a/modules/transactionpool/standard.go
+++ b/modules/transactionpool/standard.go
@@ -20,9 +20,10 @@ func (tp *TransactionPool) ValidateTransactionSet(ts []types.Transaction) error 
 		return fmt.Errorf("failed to fetch block at height %d", blockHeight)
 	}
 	ctx := types.ValidationContext{
-		Confirmed:   false,
-		BlockHeight: blockHeight,
-		BlockTime:   block.Timestamp,
+		Confirmed:         false,
+		BlockHeight:       blockHeight,
+		BlockTime:         block.Timestamp,
+		IsBlockCreatingTx: false,
 	}
 	//validate each transaction in the transaction set
 	var err error

--- a/types/unlockcondition.go
+++ b/types/unlockcondition.go
@@ -173,6 +173,11 @@ type (
 		// BlockTime defines the time of the currently last registered block,
 		// the transaction belonged to.
 		BlockTime Timestamp
+		// IsBlockCreatingTx defines if a transaction is used for the sole purpose
+		// of creating a block. More specifically, a transaction is considered a
+		// block creating transaction if it only respends a blockstake output
+		// for the purpose of the proof of blockstake protocol
+		IsBlockCreatingTx bool
 	}
 
 	// FulfillmentSignContext is given as part of the sign call of an UnlockFullment,

--- a/types/validtransaction.go
+++ b/types/validtransaction.go
@@ -21,6 +21,7 @@ var (
 	ErrArbitraryDataTooLarge         = errors.New("arbitrary data is too large to fit in a transaction")
 	ErrCoinInputOutputMismatch       = errors.New("coin inputs do not equal coin outputs for transaction")
 	ErrBlockStakeInputOutputMismatch = errors.New("blockstake inputs do not equal blockstake outputs for transaction")
+	ErrMissingMinerFee               = errors.New("transaction does not specify any miner fees")
 )
 
 // MissingCoinOutputError is returned in case a non-existing coin output is spend by a Tx.
@@ -55,7 +56,7 @@ func TransactionFitsInABlock(t Transaction, blockSizeLimit uint64) error {
 
 // TransactionFollowsMinimumValues checks that all outputs adhere to the rules for the
 // minimum allowed values
-func TransactionFollowsMinimumValues(t Transaction, minimumMinerFee Currency) error {
+func TransactionFollowsMinimumValues(t Transaction, minimumMinerFee Currency, IsBlockCreatingTx bool) error {
 	for _, sco := range t.CoinOutputs {
 		if sco.Value.IsZero() {
 			return ErrZeroOutput
@@ -70,6 +71,11 @@ func TransactionFollowsMinimumValues(t Transaction, minimumMinerFee Currency) er
 		if fee.Cmp(minimumMinerFee) == -1 {
 			return ErrTooSmallMinerFee
 		}
+	}
+	// also reject abscent miner fees is the minimum fee is non zero
+	// block creation transactions are exempt from this rule
+	if !IsBlockCreatingTx && len(t.MinerFees) == 0 && !minimumMinerFee.IsZero() {
+		return ErrMissingMinerFee
 	}
 	return nil
 }
@@ -118,7 +124,7 @@ func DefaultTransactionValidation(t Transaction, ctx ValidationContext, constant
 	if err != nil {
 		return
 	}
-	err = TransactionFollowsMinimumValues(t, constants.MinimumMinerFee)
+	err = TransactionFollowsMinimumValues(t, constants.MinimumMinerFee, ctx.IsBlockCreatingTx)
 	if err != nil {
 		return
 	}

--- a/types/validtransaction_test.go
+++ b/types/validtransaction_test.go
@@ -54,30 +54,36 @@ func TestTransactionFollowsMinimumValues_V0(t *testing.T) {
 		BlockStakeOutputs: []BlockStakeOutput{{Value: NewCurrency64(1)}},
 		MinerFees:         []Currency{NewCurrency64(1)},
 	}
-	err := TransactionFollowsMinimumValues(txn, NewCurrency64(1))
+	err := TransactionFollowsMinimumValues(txn, NewCurrency64(1), false)
 	if err != nil {
 		t.Error(err)
 	}
 
 	// Try a zero value for each type.
 	txn.CoinOutputs[0].Value = ZeroCurrency
-	err = TransactionFollowsMinimumValues(txn, NewCurrency64(1))
+	err = TransactionFollowsMinimumValues(txn, NewCurrency64(1), false)
 	if err != ErrZeroOutput {
 		t.Error(err)
 	}
 	txn.CoinOutputs[0].Value = NewCurrency64(1)
 	txn.BlockStakeOutputs[0].Value = ZeroCurrency
-	err = TransactionFollowsMinimumValues(txn, NewCurrency64(1))
+	err = TransactionFollowsMinimumValues(txn, NewCurrency64(1), false)
 	if err != ErrZeroOutput {
 		t.Error(err)
 	}
 	txn.BlockStakeOutputs[0].Value = NewCurrency64(1)
 	txn.MinerFees[0] = ZeroCurrency
-	err = TransactionFollowsMinimumValues(txn, NewCurrency64(1))
+	err = TransactionFollowsMinimumValues(txn, NewCurrency64(1), false)
 	if err != ErrTooSmallMinerFee {
 		t.Error(err)
 	}
-	txn.MinerFees[0] = NewCurrency64(1)
+	// specifically test for miissing miner fees
+	txn.MinerFees = nil
+	err = TransactionFollowsMinimumValues(txn, NewCurrency64(1), false)
+	if err != ErrMissingMinerFee {
+		t.Error(err)
+	}
+	txn.MinerFees = append(txn.MinerFees, NewCurrency64(1))
 }
 
 // TestTransactionFollowsMinimumValues_Vd probes the
@@ -90,30 +96,36 @@ func TestTransactionFollowsMinimumValues_Vd(t *testing.T) {
 		BlockStakeOutputs: []BlockStakeOutput{{Value: NewCurrency64(1)}},
 		MinerFees:         []Currency{NewCurrency64(1)},
 	}
-	err := TransactionFollowsMinimumValues(txn, NewCurrency64(1))
+	err := TransactionFollowsMinimumValues(txn, NewCurrency64(1), false)
 	if err != nil {
 		t.Error(err)
 	}
 
 	// Try a zero value for each type.
 	txn.CoinOutputs[0].Value = ZeroCurrency
-	err = TransactionFollowsMinimumValues(txn, NewCurrency64(1))
+	err = TransactionFollowsMinimumValues(txn, NewCurrency64(1), false)
 	if err != ErrZeroOutput {
 		t.Error(err)
 	}
 	txn.CoinOutputs[0].Value = NewCurrency64(1)
 	txn.BlockStakeOutputs[0].Value = ZeroCurrency
-	err = TransactionFollowsMinimumValues(txn, NewCurrency64(1))
+	err = TransactionFollowsMinimumValues(txn, NewCurrency64(1), false)
 	if err != ErrZeroOutput {
 		t.Error(err)
 	}
 	txn.BlockStakeOutputs[0].Value = NewCurrency64(1)
 	txn.MinerFees[0] = ZeroCurrency
-	err = TransactionFollowsMinimumValues(txn, NewCurrency64(1))
+	err = TransactionFollowsMinimumValues(txn, NewCurrency64(1), false)
 	if err != ErrTooSmallMinerFee {
 		t.Error(err)
 	}
-	txn.MinerFees[0] = NewCurrency64(1)
+	// specifically test for miissing miner fees
+	txn.MinerFees = nil
+	err = TransactionFollowsMinimumValues(txn, NewCurrency64(1), false)
+	if err != ErrMissingMinerFee {
+		t.Error(err)
+	}
+	txn.MinerFees = append(txn.MinerFees, NewCurrency64(1))
 }
 
 // TestValidateNoDoubleSpendsWithinTransaction_V0 probes


### PR DESCRIPTION
Require that all transactions define a high enough fee (except for transactions explicitly created by block creators for the POBS protocol). Previously it was possible to create transactions without fees (though 0 value fees were correctly rejected)