### PR TITLE
Added support for bootstrap-peers flag in cli

### DIFF
--- a/cmd/rivined/commands.go
+++ b/cmd/rivined/commands.go
@@ -15,7 +15,7 @@ import (
 )
 
 type commands struct {
-	cfg           daemon.Config
+	cfg           ExtendedDaemonConfig
 	moduleSetFlag daemon.ModuleSetFlag
 }
 
@@ -52,7 +52,7 @@ func (cmds *commands) rootCommand(*cobra.Command, []string) {
 	}
 
 	// Process the config variables, cleaning up slightly invalid values
-	cmds.cfg = daemon.ProcessConfig(cmds.cfg)
+	cmds.cfg.Config = daemon.ProcessConfig(cmds.cfg.Config)
 
 	// run daemon
 	err = runDaemon(cmds.cfg, networkCfg, cmds.moduleSetFlag.ModuleIdentifiers())

--- a/cmd/rivined/config.go
+++ b/cmd/rivined/config.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"github.com/threefoldtech/rivine/modules"
+	"github.com/threefoldtech/rivine/pkg/daemon"
+)
+
+// ExtendedDaemonConfig contains all configurable variables for rivine.
+type ExtendedDaemonConfig struct {
+	daemon.Config
+
+	BootstrapPeers []modules.NetAddress
+}

--- a/cmd/rivined/daemon.go
+++ b/cmd/rivined/daemon.go
@@ -20,7 +20,7 @@ import (
 	"github.com/threefoldtech/rivine/pkg/daemon"
 )
 
-func runDaemon(cfg daemon.Config, networkCfg daemon.NetworkConfig, moduleIdentifiers daemon.ModuleIdentifierSet) error {
+func runDaemon(cfg ExtendedDaemonConfig, networkCfg daemon.NetworkConfig, moduleIdentifiers daemon.ModuleIdentifierSet) error {
 	// Print a startup message.
 	fmt.Println("Loading...")
 	loadStart := time.Now()

--- a/cmd/rivined/daemon.go
+++ b/cmd/rivined/daemon.go
@@ -54,7 +54,7 @@ func runDaemon(cfg ExtendedDaemonConfig, networkCfg daemon.NetworkConfig, module
 		printModuleIsLoading("gateway")
 		g, err = gateway.New(cfg.RPCaddr, !cfg.NoBootstrap,
 			filepath.Join(cfg.RootPersistentDir, modules.GatewayDir),
-			cfg.BlockchainInfo, networkCfg.Constants, networkCfg.BootstrapPeers, cfg.VerboseLogging)
+			cfg.BlockchainInfo, networkCfg.Constants, cfg.BootstrapPeers, cfg.VerboseLogging)
 		if err != nil {
 			return err
 		}

--- a/cmd/rivined/main.go
+++ b/cmd/rivined/main.go
@@ -13,7 +13,7 @@ import (
 func main() {
 	var cmds commands
 	// load default config to start with
-	cmds.cfg = daemon.DefaultConfig()
+	cmds.cfg.Config = daemon.DefaultConfig()
 	// load default config flag
 	cmds.moduleSetFlag = daemon.DefaultModuleSetFlag()
 
@@ -29,6 +29,14 @@ func main() {
 	cmds.cfg.RegisterAsFlags(root.Flags())
 	// also add our modules as a flag
 	cmds.moduleSetFlag.RegisterFlag(root.Flags(), fmt.Sprintf("%s modules", os.Args[0]))
+
+	// custom flags
+	cli.NetAddressArrayFlagVar(
+		root.Flags(),
+		&cmds.cfg.BootstrapPeers,
+		"bootstrap-peers",
+		"overwrite the bootstrap peers to use, instead of using the default bootstrap peers",
+	)
 
 	// create the other commands
 	root.AddCommand(&cobra.Command{


### PR DESCRIPTION
This links to https://github.com/threefoldtech/rivine/issues/502.
Adds support for bootstrap-peers flag in Rivine daemon CLI. 

@robvanmieghem is there any way to test this flag in Rivine? 