### PR TITLE
Blockcreate tx

### DIFF
--- a/cmd/rivined/daemon.go
+++ b/cmd/rivined/daemon.go
@@ -18,6 +18,7 @@ import (
 	"github.com/threefoldtech/rivine/modules/wallet"
 	"github.com/threefoldtech/rivine/pkg/api"
 	"github.com/threefoldtech/rivine/pkg/daemon"
+	"github.com/threefoldtech/rivine/types"
 )
 
 func runDaemon(cfg daemon.Config, networkCfg daemon.NetworkConfig, moduleIdentifiers daemon.ModuleIdentifierSet) error {
@@ -85,6 +86,7 @@ func runDaemon(cfg daemon.Config, networkCfg daemon.NetworkConfig, moduleIdentif
 				fmt.Println("Error during consensus set shutdown:", err)
 			}
 		}()
+		types.RegisterTransactionVersion(types.TransactionVersionBlockCreation, types.NewBlockCreationTransactionController(cs))
 
 	}
 	var tpool modules.TransactionPool

--- a/modules/blockcreator/proofofblockstake.go
+++ b/modules/blockcreator/proofofblockstake.go
@@ -158,6 +158,10 @@ func (bc *BlockCreator) RespentBlockStake(ubso types.UnspentBlockStakeOutput) er
 		}
 	}
 
+	// get current height so we can store the block height of the block the tx is
+	// supposed to make in the block (currentHeight + 1)
+	currentHeight := bc.cs.Height()
+
 	bso, err := bc.cs.GetBlockStakeOutput(ubso.BlockStakeOutputID)
 	if err != nil {
 		return err
@@ -176,7 +180,7 @@ func (bc *BlockCreator) RespentBlockStake(ubso types.UnspentBlockStakeOutput) er
 	input := types.BlockStakeInput{ParentID: ubso.BlockStakeOutputID, Fulfillment: types.NewFulfillment(types.NewSingleSignatureFulfillment(pk))}
 
 	// create the extension for the block creation tx based on the used input
-	txExt := &types.BlockCreationTransactionExtension{Reference: input}
+	txExt := &types.BlockCreationTransactionExtension{Reference: input, Height: types.BlockHeight(currentHeight + 1)}
 
 	// Create transactionbuilder for the new transaction and add the extension
 	txb := bc.wallet.StartTransactionWithVersion(types.TransactionVersionBlockCreation)

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -192,6 +192,9 @@ type (
 		// AddArbitraryData sets the arbitrary data of the transaction.
 		SetArbitraryData(arb []byte)
 
+		// SetExtension sets the extension of the transaction
+		SetExtension(interface{})
+
 		// Sign will sign any inputs added by 'FundCoins' or 'FundBlockStakes'
 		// and return a transaction set that contains all parents prepended to
 		// the transaction. If more fields need to be added, a new transaction
@@ -388,6 +391,10 @@ type (
 		// StartTransaction is a convenience method that calls
 		// RegisterTransaction(types.Transaction{}, nil)
 		StartTransaction() TransactionBuilder
+
+		// StartTransactionWithVersion is a convenience function that calls
+		// RegisterTransaction(types.Transaction{Version: version}, nil).
+		StartTransactionWithVersion(types.TransactionVersion) TransactionBuilder
 
 		// SendCoins is a tool for sending coins from the wallet to anyone who can fulfill the
 		// given condition (can be nil). The transaction is automatically given to the transaction pool, and

--- a/modules/wallet/transactionbuilder.go
+++ b/modules/wallet/transactionbuilder.go
@@ -354,6 +354,11 @@ func (tb *transactionBuilder) SetArbitraryData(arb []byte) {
 	tb.transaction.ArbitraryData = arb
 }
 
+// SetExtension sets the extension of the transaction
+func (tb *transactionBuilder) SetExtension(extension interface{}) {
+	tb.transaction.Extension = extension
+}
+
 // Drop discards all of the outputs in a transaction, returning them to the
 // pool so that other transactions may use them. 'Drop' should only be called
 // if a transaction is both unsigned and will not be used any further.

--- a/types/transactions_blockcreation.go
+++ b/types/transactions_blockcreation.go
@@ -242,6 +242,15 @@ func (bctc BlockCreationTransactionController) ValidateTransaction(t Transaction
 		return err
 	}
 
+	bso, err := bctc.bsog.GetBlockStakeOutput(bctx.Reference.ParentID)
+	if err != nil {
+		return fmt.Errorf("failed to get the referenced blockstake output condition condition: %v", err)
+	}
+
+	if err = bso.Condition.Fulfill(bctx.Reference.Fulfillment, FulfillContext{BlockHeight: ctx.BlockHeight, BlockTime: ctx.BlockTime, Transaction: t, ExtraObjects: nil}); err != nil {
+		return err
+	}
+
 	// check block height in tx
 	if bctx.Height != ctx.BlockHeight {
 		return fmt.Errorf("tx is supposed to create block %v, but is in block %v", bctx.Height, ctx.BlockHeight)
@@ -295,7 +304,7 @@ func (bctc BlockCreationTransactionController) SignExtension(extension interface
 
 	bso, err := bctc.bsog.GetBlockStakeOutput(bctxExtension.Reference.ParentID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get the active mint condition: %v", err)
+		return nil, fmt.Errorf("failed to get the referenced blockstake output condition condition: %v", err)
 	}
 	err = sign(&bctxExtension.Reference.Fulfillment, bso.Condition)
 	if err != nil {

--- a/types/transactions_blockcreation.go
+++ b/types/transactions_blockcreation.go
@@ -1,0 +1,270 @@
+package types
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/threefoldtech/rivine/crypto"
+	"github.com/threefoldtech/rivine/pkg/encoding/rivbin"
+)
+
+// These Specifiers are used internally when calculating a type's ID. See
+// Specifier for more details.
+var (
+	SpecifierBlockCreationTransaction = Specifier{'b', 'l', 'o', 'c', 'k', ' ', 'c', 'r', 'e', 'a', 't', 'i', 'o', 'n'}
+)
+
+const (
+	// TransactionVersionBlockCreation defines the special transaction used for
+	// creating blocks by referencing an owned blockstake output
+	TransactionVersionBlockCreation TransactionVersion = 2
+)
+
+type (
+	// BlockCreationTransaction defines the transaction (with version 0x02)
+	// used to create a new block by proving ownership of a referenced
+	// blockstake output
+	BlockCreationTransaction struct {
+		// Reference unlocks a blockstake output to prove ownership, but does not consume it
+		Reference BlockStakeInput
+	}
+
+	// BlockCreationTransactionExtension defines the BlockCreationTransaction Extension Data
+	BlockCreationTransactionExtension struct {
+		// Reference unlocks a blockstake output to prove ownership, but does not consume it
+		Reference BlockStakeInput
+	}
+)
+
+// BlockCreationTransactionFromTransaction creates a BlockCreationTransaction, using a regular in-memory rivine transaction
+func BlockCreationTransactionFromTransaction(tx Transaction) (BlockCreationTransaction, error) {
+	if tx.Version != TransactionVersionBlockCreation {
+		return BlockCreationTransaction{}, fmt.Errorf(
+			"block creation transaction requires tx version %d", TransactionVersionBlockCreation,
+		)
+	}
+	return BlockCreationTransactionFromTransactionData(TransactionData{
+		CoinInputs:        tx.CoinInputs,
+		CoinOutputs:       tx.CoinOutputs,
+		BlockStakeInputs:  tx.BlockStakeInputs,
+		BlockStakeOutputs: tx.BlockStakeOutputs,
+		MinerFees:         tx.MinerFees,
+		ArbitraryData:     tx.ArbitraryData,
+		Extension:         tx.Extension,
+	})
+}
+
+// BlockCreationTransactionFromTransactionData creates an BlockCreationTransaction,
+// using the TransactionData from a regular in-memory rivine transaction.
+func BlockCreationTransactionFromTransactionData(txData TransactionData) (BlockCreationTransaction, error) {
+	// validate transaction data
+
+	// no coin inputs or outputs allowed
+	if len(txData.CoinInputs) != 0 || len(txData.CoinOutputs) != 0 {
+		return BlockCreationTransaction{}, errors.New("no coin input or outputs allowed for a block creation transaction")
+	}
+
+	// no miner fee allowed
+	if len(txData.MinerFees) != 0 {
+		return BlockCreationTransaction{}, errors.New("no transaction fees allowed for a block creation transaction")
+	}
+
+	// no arb data allowed
+	if len(txData.ArbitraryData) != 0 {
+		return BlockCreationTransaction{}, errors.New("no arbitrary data allowed for a block creation transaction")
+	}
+
+	// no blockstake input and outputs allowed, can't move block stakes
+	if len(txData.BlockStakeOutputs) != 0 || len(txData.BlockStakeInputs) != 0 {
+		return BlockCreationTransaction{}, errors.New("no blockstake outputs allowed for a block creation transaction")
+	}
+
+	extensionData, ok := txData.Extension.(*BlockCreationTransactionExtension)
+	if !ok {
+		return BlockCreationTransaction{}, errors.New("invalid extension data for a block creation transaction")
+	}
+
+	tx := BlockCreationTransaction{
+		Reference: extensionData.Reference,
+	}
+
+	return tx, nil
+}
+
+// TransactionData returns this BlockCreationTransaction
+// as regular rivine transaction data.
+func (bctx *BlockCreationTransaction) TransactionData() TransactionData {
+	txData := TransactionData{
+		Extension: &BlockCreationTransactionExtension{
+			Reference: bctx.Reference,
+		},
+	}
+	return txData
+}
+
+// Transaction returns this BlockCreationTransaction
+// as regular rivine transaction, using TransactionVersionBlockCreation as the type.
+func (bctx *BlockCreationTransaction) Transaction() Transaction {
+	tx := Transaction{
+		Version: TransactionVersionBlockCreation,
+		Extension: &BlockCreationTransactionExtension{
+			Reference: bctx.Reference,
+		},
+	}
+	return tx
+}
+
+// MarshalSia implements SiaMarshaler.MarshalSia,
+// alias of MarshalRivine for backwards-compatibility reasons.
+func (bctx BlockCreationTransaction) MarshalSia(w io.Writer) error {
+	return bctx.MarshalRivine(w)
+}
+
+// UnmarshalSia implements SiaUnmarshaler.UnmarshalSia,
+// alias of UnmarshalRivine for backwards-compatibility reasons.
+func (bctx *BlockCreationTransaction) UnmarshalSia(r io.Reader) error {
+	return bctx.UnmarshalRivine(r)
+}
+
+// MarshalRivine implements RivineMarshaler.MarshalRivine
+func (bctx BlockCreationTransaction) MarshalRivine(w io.Writer) error {
+	return rivbin.NewEncoder(w).EncodeAll(
+		bctx.Reference,
+	)
+}
+
+// UnmarshalRivine implements RivineUnmarshaler.UnmarshalRivine
+func (bctx *BlockCreationTransaction) UnmarshalRivine(r io.Reader) error {
+	return rivbin.NewDecoder(r).DecodeAll(
+		&bctx.Reference,
+	)
+}
+
+type (
+	// BlockCreationTransactionController defines a transaction controller for a a transaction type
+	// reserved at type 0x02. It allows creation of blocks without blockstake respend
+	BlockCreationTransactionController struct{}
+)
+
+var (
+	// ensure at compile time that BlockCreationTransactionController
+	// implements the desired interfaces
+	_ TransactionController      = BlockCreationTransactionController{}
+	_ TransactionValidator       = BlockCreationTransactionController{}
+	_ CoinOutputValidator        = BlockCreationTransactionController{}
+	_ BlockStakeOutputValidator  = BlockCreationTransactionController{}
+	_ TransactionSignatureHasher = BlockCreationTransactionController{}
+	_ TransactionIDEncoder       = BlockCreationTransactionController{}
+)
+
+// EncodeTransactionData implements TransactionController.EncodeTransactionData
+func (bctc BlockCreationTransactionController) EncodeTransactionData(w io.Writer, txData TransactionData) error {
+	bctx, err := BlockCreationTransactionFromTransactionData(txData)
+	if err != nil {
+		return fmt.Errorf("failed to convert txData to a BlockCreationTx: %v", err)
+	}
+	return rivbin.NewEncoder(w).Encode(bctx)
+}
+
+// DecodeTransactionData implements TransactionController.DecodeTransactionData
+func (bctc BlockCreationTransactionController) DecodeTransactionData(r io.Reader) (TransactionData, error) {
+	var bctx BlockCreationTransaction
+	err := rivbin.NewDecoder(r).Decode(&bctx)
+	if err != nil {
+		return TransactionData{}, fmt.Errorf(
+			"failed to binary-decode tx as a BlockCreationTx: %v", err)
+	}
+	// return block creation tx as regular rivine tx data
+	return bctx.TransactionData(), nil
+}
+
+// JSONEncodeTransactionData implements TransactionController.JSONEncodeTransactionData
+func (bctc BlockCreationTransactionController) JSONEncodeTransactionData(txData TransactionData) ([]byte, error) {
+	bctx, err := BlockCreationTransactionFromTransactionData(txData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert txData to a BlockCreationTx: %v", err)
+	}
+	return json.Marshal(bctx)
+}
+
+// JSONDecodeTransactionData implements TransactionController.JSONDecodeTransactionData
+func (bctc BlockCreationTransactionController) JSONDecodeTransactionData(data []byte) (TransactionData, error) {
+	var bctx BlockCreationTransaction
+	err := json.Unmarshal(data, &bctx)
+	if err != nil {
+		return TransactionData{}, fmt.Errorf(
+			"failed to json-decode tx as a BlockCreationTx:: %v", err)
+	}
+	// return block creation tx as regular rivine tx data
+	return bctx.TransactionData(), nil
+}
+
+// ValidateTransaction implements TransactionValidator.ValidateTransaction
+func (bctc BlockCreationTransactionController) ValidateTransaction(t Transaction, ctx ValidationContext, constants TransactionValidationConstants) error {
+	// check tx fits within a block
+	err := TransactionFitsInABlock(t, constants.BlockSizeLimit)
+	if err != nil {
+		return err
+	}
+
+	// get BlockCreationTx
+	bctx, err := BlockCreationTransactionFromTransaction(t)
+	if err != nil {
+		return fmt.Errorf("failed to use tx as a BlockCreationTx: %v", err)
+	}
+
+	// check if the reference is a standard fulfillment
+	if err = bctx.Reference.Fulfillment.IsStandardFulfillment(ctx); err != nil {
+		return err
+	}
+
+	// Tx is valid
+	return nil
+}
+
+// ValidateCoinOutputs implements CoinOutputValidator.ValidateCoinOutputs,
+func (bctc BlockCreationTransactionController) ValidateCoinOutputs(t Transaction, ctx FundValidationContext, coinInputs map[CoinOutputID]CoinOutput) error {
+	// no coin input and outputs
+	return nil
+}
+
+// ValidateBlockStakeOutputs implements BlockStakeOutputValidator.ValidateBlockStakeOutputs
+func (bctc BlockCreationTransactionController) ValidateBlockStakeOutputs(t Transaction, ctx FundValidationContext, blockStakeInputs map[BlockStakeOutputID]BlockStakeOutput) (err error) {
+	return nil // always valid, no block stake inputs/outputs
+}
+
+// SignatureHash implements TransactionSignatureHasher.SignatureHash
+func (bctc BlockCreationTransactionController) SignatureHash(t Transaction, extraObjects ...interface{}) (crypto.Hash, error) {
+	bctx, err := BlockCreationTransactionFromTransaction(t)
+	if err != nil {
+		return crypto.Hash{}, fmt.Errorf("failed to use tx as a BlockCreationTx: %v", err)
+	}
+
+	h := crypto.NewHash()
+	enc := rivbin.NewEncoder(h)
+
+	enc.EncodeAll(
+		t.Version,
+		SpecifierBlockCreationTransaction,
+		bctx.Reference.ParentID,
+	)
+
+	if len(extraObjects) > 0 {
+		enc.EncodeAll(extraObjects...)
+	}
+
+	var hash crypto.Hash
+	h.Sum(hash[:0])
+	return hash, nil
+}
+
+// EncodeTransactionIDInput implements TransactionIDEncoder.EncodeTransactionIDInput
+func (bctc BlockCreationTransactionController) EncodeTransactionIDInput(w io.Writer, txData TransactionData) error {
+	bctx, err := BlockCreationTransactionFromTransactionData(txData)
+	if err != nil {
+		return fmt.Errorf("failed to convert txData to a BlockCreationTx: %v", err)
+	}
+	return rivbin.NewEncoder(w).EncodeAll(SpecifierBlockCreationTransaction, bctx)
+}

--- a/types/transactions_blockcreation.go
+++ b/types/transactions_blockcreation.go
@@ -153,8 +153,6 @@ var (
 	// implements the desired interfaces
 	_ TransactionController      = BlockCreationTransactionController{}
 	_ TransactionValidator       = BlockCreationTransactionController{}
-	_ CoinOutputValidator        = BlockCreationTransactionController{}
-	_ BlockStakeOutputValidator  = BlockCreationTransactionController{}
 	_ TransactionSignatureHasher = BlockCreationTransactionController{}
 	_ TransactionIDEncoder       = BlockCreationTransactionController{}
 )
@@ -222,17 +220,6 @@ func (bctc BlockCreationTransactionController) ValidateTransaction(t Transaction
 
 	// Tx is valid
 	return nil
-}
-
-// ValidateCoinOutputs implements CoinOutputValidator.ValidateCoinOutputs,
-func (bctc BlockCreationTransactionController) ValidateCoinOutputs(t Transaction, ctx FundValidationContext, coinInputs map[CoinOutputID]CoinOutput) error {
-	// no coin input and outputs
-	return nil
-}
-
-// ValidateBlockStakeOutputs implements BlockStakeOutputValidator.ValidateBlockStakeOutputs
-func (bctc BlockCreationTransactionController) ValidateBlockStakeOutputs(t Transaction, ctx FundValidationContext, blockStakeInputs map[BlockStakeOutputID]BlockStakeOutput) (err error) {
-	return nil // always valid, no block stake inputs/outputs
 }
 
 // SignatureHash implements TransactionSignatureHasher.SignatureHash


### PR DESCRIPTION
Add a new transaction version 0x02, known as a block create transaction. This transaction has no input or outputs, and fulfills a blockstake output in its extension. The POBS algorithm recognizes this as an alternative for "old" block creation transactions which explicitly respend the blockstakes. Additionally, the extension data also includes a height, this is the height of the block which will have been created by this transaction. If this height does not match, the transaction is invalid. This field is thus unique, and ensures a unique tx ID in case the same blockstake output gets unlocked multiple times