### PR TITLE
Improve RPC rate limiting

### DIFF
--- a/cmd/rivined/daemon.go
+++ b/cmd/rivined/daemon.go
@@ -22,6 +22,11 @@ import (
 	"github.com/threefoldtech/rivine/pkg/daemon"
 )
 
+const (
+	// maxConcurrentRPC is the maximum number of concurrent RPC calls allowed for a single daemon
+	maxConcurrentRPC = 1
+)
+
 func runDaemon(cfg daemon.Config, networkCfg daemon.NetworkConfig, moduleIdentifiers daemon.ModuleIdentifierSet) error {
 	// Print a startup message.
 	fmt.Println("Loading...")
@@ -58,7 +63,7 @@ func runDaemon(cfg daemon.Config, networkCfg daemon.NetworkConfig, moduleIdentif
 	var g modules.Gateway
 	if moduleIdentifiers.Contains(daemon.GatewayModule.Identifier()) {
 		printModuleIsLoading("gateway")
-		g, err = gateway.New(cfg.RPCaddr, !cfg.NoBootstrap,
+		g, err = gateway.New(cfg.RPCaddr, !cfg.NoBootstrap, maxConcurrentRPC,
 			filepath.Join(cfg.RootPersistentDir, modules.GatewayDir),
 			cfg.BlockchainInfo, networkCfg.Constants, networkCfg.BootstrapPeers, cfg.VerboseLogging)
 		if err != nil {

--- a/modules/consensus/consensusset_test.go
+++ b/modules/consensus/consensusset_test.go
@@ -83,7 +83,7 @@ func blankConsensusSetTester(name string) (*consensusSetTester, error) {
 	testdir := build.TempDir(modules.ConsensusDir, name)
 
 	// Create modules.
-	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir), types.DefaultBlockchainInfo(), types.TestnetChainConstants(), nil, false)
+	g, err := gateway.New("localhost:0", false, 1, filepath.Join(testdir, modules.GatewayDir), types.DefaultBlockchainInfo(), types.TestnetChainConstants(), nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/gateway/consts.go
+++ b/modules/gateway/consts.go
@@ -75,15 +75,6 @@ var (
 		Testing:  1 * time.Second,
 	}).(time.Duration)
 
-	// peerRPCDelay defines the amount of time waited between each RPC accepted
-	// from a peer. Without this delay, a peer can force us to spin up thousands
-	// of goroutines per second.
-	peerRPCDelay = build.Select(build.Var{
-		Standard: 3 * time.Second,
-		Dev:      1 * time.Second,
-		Testing:  20 * time.Millisecond,
-	}).(time.Duration)
-
 	// pruneNodeListLen defines the number of nodes that the gateway must have
 	// to be pruning nodes from the node list.
 	pruneNodeListLen = build.Select(build.Var{

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -116,9 +116,10 @@ var (
 
 // Gateway implements the modules.Gateway interface.
 type Gateway struct {
-	listener net.Listener
-	myAddr   modules.NetAddress
-	port     string
+	listener             net.Listener
+	myAddr               modules.NetAddress
+	port                 string
+	concurrentRPCPerPeer uint64
 
 	// handlers are the RPCs that the Gateway can handle.
 	//
@@ -191,7 +192,7 @@ func (g *Gateway) Close() error {
 }
 
 // New returns an initialized Gateway.
-func New(addr string, bootstrap bool, persistDir string, bcInfo types.BlockchainInfo, chainCts types.ChainConstants, bootstrapPeers []modules.NetAddress, verboseLogging bool) (*Gateway, error) {
+func New(addr string, bootstrap bool, concurrentRPCPerPeer uint64, persistDir string, bcInfo types.BlockchainInfo, chainCts types.ChainConstants, bootstrapPeers []modules.NetAddress, verboseLogging bool) (*Gateway, error) {
 	// Create the directory if it doesn't exist.
 	err := os.MkdirAll(persistDir, 0700)
 	if err != nil {
@@ -199,6 +200,8 @@ func New(addr string, bootstrap bool, persistDir string, bcInfo types.Blockchain
 	}
 
 	g := &Gateway{
+		concurrentRPCPerPeer: concurrentRPCPerPeer,
+
 		handlers: make(map[rpcID]modules.RPCFunc),
 		initRPCs: make(map[string]modules.RPCFunc),
 

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -21,7 +21,7 @@ func newTestingGateway(t *testing.T) *Gateway {
 		build.Critical("newTestingGateway called during short test")
 	}
 
-	g, err := New("localhost:0", false, build.TempDir("gateway", t.Name()),
+	g, err := New("localhost:0", false, 1, build.TempDir("gateway", t.Name()),
 		types.DefaultBlockchainInfo(), types.TestnetChainConstants(), nil, false)
 	if err != nil {
 		build.Critical(err)
@@ -36,7 +36,7 @@ func newNamedTestingGateway(t *testing.T, suffix string) *Gateway {
 		build.Critical("newTestingGateway called during short test")
 	}
 
-	g, err := New("localhost:0", false, build.TempDir("gateway", t.Name()+suffix),
+	g, err := New("localhost:0", false, 1, build.TempDir("gateway", t.Name()+suffix),
 		types.DefaultBlockchainInfo(), types.TestnetChainConstants(), nil, false)
 	if err != nil {
 		build.Critical(err)
@@ -132,13 +132,13 @@ func TestNew(t *testing.T) {
 
 	bcInfo := types.DefaultBlockchainInfo()
 	cts := types.TestnetChainConstants()
-	if _, err := New("", false, "", bcInfo, cts, nil, false); err == nil {
+	if _, err := New("", false, 1, "", bcInfo, cts, nil, false); err == nil {
 		t.Fatal("expecting persistDir error, got nil")
 	}
-	if _, err := New("localhost:0", false, "", bcInfo, cts, nil, false); err == nil {
+	if _, err := New("localhost:0", false, 1, "", bcInfo, cts, nil, false); err == nil {
 		t.Fatal("expecting persistDir error, got nil")
 	}
-	if g, err := New("foo", false, build.TempDir("gateway", t.Name()+"1"), bcInfo, cts, nil, false); err == nil {
+	if g, err := New("foo", false, 1, build.TempDir("gateway", t.Name()+"1"), bcInfo, cts, nil, false); err == nil {
 		t.Fatal("expecting listener error, got nil", g.myAddr)
 	}
 	// create corrupted nodes.json
@@ -148,7 +148,7 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Fatal("couldn't create corrupted file:", err)
 	}
-	if _, err := New("localhost:0", false, dir, bcInfo, cts, nil, false); err == nil {
+	if _, err := New("localhost:0", false, 1, dir, bcInfo, cts, nil, false); err == nil {
 		t.Fatal("expected load error, got nil")
 	}
 }

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -71,8 +71,10 @@ func TestAcceptPeer(t *testing.T) {
 				Inbound:    false,
 				Local:      false,
 			},
-			sess: newSmuxClient(new(dummyConn)),
+			sess:  newSmuxClient(new(dummyConn)),
+			token: make(chan struct{}, 1),
 		}
+		p.token <- struct{}{}
 		unkickablePeers = append(unkickablePeers, p)
 	}
 	for i := 0; i < fullyConnectedThreshold+1; i++ {
@@ -756,7 +758,7 @@ func TestPeerManagerPriority(t *testing.T) {
 
 	// Restart g1. It should immediately reconnect to g2, and then g3 after a
 	// delay.
-	g1, err = New(string(g1.myAddr), false, g1.persistDir,
+	g1, err = New(string(g1.myAddr), false, 1, g1.persistDir,
 		types.DefaultBlockchainInfo(), types.TestnetChainConstants(), nil, false)
 	if err != nil {
 		t.Fatal(err)

--- a/modules/gateway/persist_test.go
+++ b/modules/gateway/persist_test.go
@@ -23,7 +23,7 @@ func TestLoad(t *testing.T) {
 	g.mu.Unlock()
 	g.Close()
 
-	g2, err := New("localhost:0", false, g.persistDir, types.DefaultBlockchainInfo(), types.TestnetChainConstants(), nil, false)
+	g2, err := New("localhost:0", false, 1, g.persistDir, types.DefaultBlockchainInfo(), types.TestnetChainConstants(), nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -177,10 +177,12 @@ func (g *Gateway) threadedListenPeer(p *peer) {
 
 		// The handler is responsible for closing the connection, though a
 		// default deadline has been set.
-		go g.threadedHandleConn(conn)
-		if !g.managedSleep(peerRPCDelay) {
-			break
-		}
+		token := <-p.token
+		go func() {
+			// make sure we always recycle the token
+			defer func() { p.token <- token }()
+			g.threadedHandleConn(conn)
+		}()
 	}
 	// Signal that the goroutine can shutdown.
 	close(peerCloseChan)

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -40,7 +40,7 @@ func createWalletTester(name string) (*walletTester, error) {
 	chainCts := types.TestnetChainConstants()
 	// Create the modules
 	testdir := build.TempDir(modules.WalletDir, name)
-	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir), bcInfo, chainCts, nil, false)
+	g, err := gateway.New("localhost:0", false, 1, filepath.Join(testdir, modules.GatewayDir), bcInfo, chainCts, nil, false)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func createWalletTesterWithStubCS(name string, cs *consensusSetStub) (*walletTes
 	chainCts := types.TestnetChainConstants()
 	// Create the modules
 	testdir := build.TempDir(modules.WalletDir, name)
-	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir), bcInfo, chainCts, nil, false)
+	g, err := gateway.New("localhost:0", false, 1, filepath.Join(testdir, modules.GatewayDir), bcInfo, chainCts, nil, false)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func createBlankWalletTester(name string) (*walletTester, error) {
 	chainCts := types.TestnetChainConstants()
 	// Create the modules
 	testdir := build.TempDir(modules.WalletDir, name)
-	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir), bcInfo, chainCts, nil, false)
+	g, err := gateway.New("localhost:0", false, 1, filepath.Join(testdir, modules.GatewayDir), bcInfo, chainCts, nil, false)
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +230,7 @@ func TestNilInputs(t *testing.T) {
 	bcInfo := types.DefaultBlockchainInfo()
 	chainCts := types.TestnetChainConstants()
 	testdir := build.TempDir(modules.WalletDir, t.Name())
-	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir), bcInfo, chainCts, nil, false)
+	g, err := gateway.New("localhost:0", false, 1, filepath.Join(testdir, modules.GatewayDir), bcInfo, chainCts, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -306,7 +306,7 @@ func TestCloseWallet(t *testing.T) {
 	bcInfo := types.DefaultBlockchainInfo()
 	chainCts := types.TestnetChainConstants()
 	testdir := build.TempDir(modules.WalletDir, t.Name())
-	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir), bcInfo, chainCts, nil, false)
+	g, err := gateway.New("localhost:0", false, 1, filepath.Join(testdir, modules.GatewayDir), bcInfo, chainCts, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Replace the sleep rate limiting implementation with a token bucket version. See #564 for details

Fix #519 
Close #564 