### PR TITLE
refactor validation interface of consensus

### DIFF
--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -88,17 +88,17 @@ type (
 
 		// Apply the block to the plugin.
 		// An error should be returned in case something went wrong.
-		ApplyBlock(block types.Block, height types.BlockHeight, bucket *persist.LazyBoltBucket) error
+		ApplyBlock(block ConsensusBlock, height types.BlockHeight, bucket *persist.LazyBoltBucket) error
 		// Revert the block from the plugin.
 		// An error should be returned in case something went wrong.
-		RevertBlock(block types.Block, height types.BlockHeight, bucket *persist.LazyBoltBucket) error
+		RevertBlock(block ConsensusBlock, height types.BlockHeight, bucket *persist.LazyBoltBucket) error
 
 		// Apply the transaction to the plugin.
 		// An error should be returned in case something went wrong.
-		ApplyTransaction(txn types.Transaction, block types.Block, height types.BlockHeight, bucket *persist.LazyBoltBucket) error
+		ApplyTransaction(txn ConsensusTransaction, height types.BlockHeight, bucket *persist.LazyBoltBucket) error
 		// Revert the transaction from the plugin.
 		// An error should be returned in case something went wrong.
-		RevertTransaction(txn types.Transaction, block types.Block, height types.BlockHeight, bucket *persist.LazyBoltBucket) error
+		RevertTransaction(txn ConsensusTransaction, height types.BlockHeight, bucket *persist.LazyBoltBucket) error
 
 		// TransactionValidatorFunctions allows the plugin to provide validation rules for all transaction versions it mapped to
 		TransactionValidatorVersionFunctionMapping() map[types.TransactionVersion][]PluginTransactionValidationFunction
@@ -121,29 +121,30 @@ type (
 
 	// PluginTransactionValidationFunction is the signature of a validator function that
 	// can be used to provide plugin-driven transaction validation, provided by (and linked to) a plugin.
-	PluginTransactionValidationFunction func(tx types.Transaction, ctx types.TransactionValidationContext, css ConsensusStateGetter, bucket *persist.LazyBoltBucket) error
+	PluginTransactionValidationFunction func(tx ConsensusTransaction, ctx types.TransactionValidationContext, bucket *persist.LazyBoltBucket) error
 
 	// TransactionValidationFunction is the signature of a validator function that
 	// can be used to provide validation rules for transactions.
-	TransactionValidationFunction func(tx types.Transaction, ctx types.TransactionValidationContext, css ConsensusStateGetter) error
+	TransactionValidationFunction func(tx ConsensusTransaction, ctx types.TransactionValidationContext) error
 
-	// ConsensusBlock is the block type as exposed by the consensus module
+	// ConsensusBlock is the block type as exposed by the consensus module,
+	// allowing you to easily find the spend coin and blockstake outputs,
+	// for any of the by-the-block defined inputs
 	ConsensusBlock struct {
 		types.Block
 
-		Height      types.BlockHeight
-		Depth       types.Target
-		ChildTarget types.Target
+		SpentCoinOutputs       map[types.CoinOutputID]types.CoinOutput
+		SpentBlockStakeOutputs map[types.BlockStakeOutputID]types.BlockStakeOutput
 	}
 
-	// ConsensusStateGetter allows looking up of consensus set data at a given state
-	// (as accessed using a single open database Transaction).
-	ConsensusStateGetter interface {
-		BlockAtID(id types.BlockID) (ConsensusBlock, error)
-		BlockAtHeight(height types.BlockHeight) (ConsensusBlock, error)
+	// ConsensusTransaction is the transaction type as exposed by the consensus module
+	// allowing you to easily find the spend coin and blockstake outputs,
+	// for any of the by-the-transaction defined inputs
+	ConsensusTransaction struct {
+		types.Transaction
 
-		UnspentCoinOutputGet(id types.CoinOutputID) (types.CoinOutput, error)
-		UnspentBlockStakeOutputGet(id types.BlockStakeOutputID) (types.BlockStakeOutput, error)
+		SpentCoinOutputs       map[types.CoinOutputID]types.CoinOutput
+		SpentBlockStakeOutputs map[types.BlockStakeOutputID]types.BlockStakeOutput
 	}
 
 	// A ConsensusChange enumerates a set of changes that occurred to the consensus set.

--- a/modules/consensus/plugin_test.go
+++ b/modules/consensus/plugin_test.go
@@ -29,22 +29,22 @@ func (plugin *testPlugin) InitPlugin(metadata *persist.Metadata, bucket *bolt.Bu
 	}
 	return *metadata, nil
 }
-func (plugin *testPlugin) ApplyBlock(block types.Block, height types.BlockHeight, bucket *persist.LazyBoltBucket) error {
+func (plugin *testPlugin) ApplyBlock(block modules.ConsensusBlock, height types.BlockHeight, bucket *persist.LazyBoltBucket) error {
 	return nil
 }
-func (plugin *testPlugin) RevertBlock(block types.Block, height types.BlockHeight, bucket *persist.LazyBoltBucket) error {
+func (plugin *testPlugin) RevertBlock(block modules.ConsensusBlock, height types.BlockHeight, bucket *persist.LazyBoltBucket) error {
 	return nil
 }
 
 // Apply the transaction to the plugin.
 // An error should be returned in case something went wrong.
-func (plugin *testPlugin) ApplyTransaction(txn types.Transaction, block types.Block, height types.BlockHeight, bucket *persist.LazyBoltBucket) error {
+func (plugin *testPlugin) ApplyTransaction(txn modules.ConsensusTransaction, height types.BlockHeight, bucket *persist.LazyBoltBucket) error {
 	return nil
 }
 
 // Revert the transaction from the plugin.
 // An error should be returned in case something went wrong.
-func (plugin *testPlugin) RevertTransaction(txn types.Transaction, block types.Block, height types.BlockHeight, bucket *persist.LazyBoltBucket) error {
+func (plugin *testPlugin) RevertTransaction(txn modules.ConsensusTransaction, height types.BlockHeight, bucket *persist.LazyBoltBucket) error {
 	return nil
 }
 

--- a/modules/consensus/validators.go
+++ b/modules/consensus/validators.go
@@ -73,19 +73,19 @@ func StandardTransactionValidators() []modules.TransactionValidationFunction {
 
 // ValidateTransactionFitsInABlock is a validator function that checks
 // if a transaction fits in a block
-func ValidateTransactionFitsInABlock(tx types.Transaction, ctx types.TransactionValidationContext, _ modules.ConsensusStateGetter) error {
-	return types.TransactionFitsInABlock(tx, ctx.BlockSizeLimit)
+func ValidateTransactionFitsInABlock(tx modules.ConsensusTransaction, ctx types.TransactionValidationContext) error {
+	return types.TransactionFitsInABlock(tx.Transaction, ctx.BlockSizeLimit)
 }
 
 // ValidateTransactionArbitraryData is a validator function that checks
 // if a transaction's arbitrary data is valid
-func ValidateTransactionArbitraryData(tx types.Transaction, ctx types.TransactionValidationContext, _ modules.ConsensusStateGetter) error {
+func ValidateTransactionArbitraryData(tx modules.ConsensusTransaction, ctx types.TransactionValidationContext) error {
 	return types.ArbitraryDataFits(tx.ArbitraryData, ctx.ArbitraryDataSizeLimit)
 }
 
 // ValidateCoinOutputsAreValid is a validator function that checks if all coin outputs are standard,
 // meaning their condition is considered standard (== known) and their (coin) value is individually greater than zero.
-func ValidateCoinOutputsAreValid(tx types.Transaction, ctx types.TransactionValidationContext, css modules.ConsensusStateGetter) error {
+func ValidateCoinOutputsAreValid(tx modules.ConsensusTransaction, ctx types.TransactionValidationContext) error {
 	var err error
 	for _, co := range tx.CoinOutputs {
 		if co.Value.IsZero() {
@@ -101,7 +101,7 @@ func ValidateCoinOutputsAreValid(tx types.Transaction, ctx types.TransactionVali
 
 // ValidateCoinInputsAreValid is a validator function that checks if all coin inputs are standard,
 // meaning their fulfillment is considered standard (== known) and their parent ID is defined.
-func ValidateCoinInputsAreValid(tx types.Transaction, ctx types.TransactionValidationContext, css modules.ConsensusStateGetter) error {
+func ValidateCoinInputsAreValid(tx modules.ConsensusTransaction, ctx types.TransactionValidationContext) error {
 	var err error
 	for _, ci := range tx.CoinInputs {
 		if ci.ParentID == (types.CoinOutputID{}) {
@@ -117,7 +117,7 @@ func ValidateCoinInputsAreValid(tx types.Transaction, ctx types.TransactionValid
 
 // ValidateBlockStakeOutputsAreValid is a validator function that checks if all block stake output is standard,
 // meaning their condition is considered standard (== known) and their (block stake) value is individually greater than zero.
-func ValidateBlockStakeOutputsAreValid(tx types.Transaction, ctx types.TransactionValidationContext, css modules.ConsensusStateGetter) error {
+func ValidateBlockStakeOutputsAreValid(tx modules.ConsensusTransaction, ctx types.TransactionValidationContext) error {
 	var err error
 	for _, bso := range tx.BlockStakeOutputs {
 		if bso.Value.IsZero() {
@@ -133,7 +133,7 @@ func ValidateBlockStakeOutputsAreValid(tx types.Transaction, ctx types.Transacti
 
 // ValidateBlockStakeInputsAreValid is a validator function that checks if all block stake inputs are standard,
 // meaning their fulfillment is considered standard (== known) and their parent ID is defined.
-func ValidateBlockStakeInputsAreValid(tx types.Transaction, ctx types.TransactionValidationContext, css modules.ConsensusStateGetter) error {
+func ValidateBlockStakeInputsAreValid(tx modules.ConsensusTransaction, ctx types.TransactionValidationContext) error {
 	var err error
 	for _, bsi := range tx.BlockStakeInputs {
 		if bsi.ParentID == (types.BlockStakeOutputID{}) {
@@ -149,7 +149,7 @@ func ValidateBlockStakeInputsAreValid(tx types.Transaction, ctx types.Transactio
 
 // ValidateMinerFeeIsPresent is a validator function that checks
 // that at least one miner fee is present
-func ValidateMinerFeeIsPresent(tx types.Transaction, ctx types.TransactionValidationContext, _ modules.ConsensusStateGetter) error {
+func ValidateMinerFeeIsPresent(tx modules.ConsensusTransaction, ctx types.TransactionValidationContext) error {
 	if ctx.IsBlockCreatingTx {
 		return nil // validation does not apply to to block creation tx
 	}
@@ -161,7 +161,7 @@ func ValidateMinerFeeIsPresent(tx types.Transaction, ctx types.TransactionValida
 
 // ValidateMinerFeesAreValid is a validator function that checks if all miner fees are valid,
 // meaning their (coin) value is individually greater than zero.
-func ValidateMinerFeesAreValid(tx types.Transaction, ctx types.TransactionValidationContext, _ modules.ConsensusStateGetter) error {
+func ValidateMinerFeesAreValid(tx modules.ConsensusTransaction, ctx types.TransactionValidationContext) error {
 	for _, fee := range tx.MinerFees {
 		if fee.Cmp(ctx.MinimumMinerFee) == -1 {
 			return types.ErrTooSmallMinerFee
@@ -171,7 +171,7 @@ func ValidateMinerFeesAreValid(tx types.Transaction, ctx types.TransactionValida
 }
 
 // ValidateDoubleCoinSpends validates that no coin output is spent twice.
-func ValidateDoubleCoinSpends(tx types.Transaction, ctx types.TransactionValidationContext, _ modules.ConsensusStateGetter) error {
+func ValidateDoubleCoinSpends(tx modules.ConsensusTransaction, ctx types.TransactionValidationContext) error {
 	spendCoins := make(map[types.CoinOutputID]struct{}, len(tx.CoinInputs))
 	for _, ci := range tx.CoinInputs {
 		if _, found := spendCoins[ci.ParentID]; found {
@@ -183,7 +183,7 @@ func ValidateDoubleCoinSpends(tx types.Transaction, ctx types.TransactionValidat
 }
 
 // ValidateDoubleBlockStakeSpends validates that no block stake output is spent twice.
-func ValidateDoubleBlockStakeSpends(tx types.Transaction, ctx types.TransactionValidationContext, _ modules.ConsensusStateGetter) error {
+func ValidateDoubleBlockStakeSpends(tx modules.ConsensusTransaction, ctx types.TransactionValidationContext) error {
 	spendBlockStakes := make(map[types.BlockStakeOutputID]struct{}, len(tx.BlockStakeInputs))
 	for _, bsi := range tx.BlockStakeInputs {
 		if _, found := spendBlockStakes[bsi.ParentID]; found {
@@ -195,29 +195,29 @@ func ValidateDoubleBlockStakeSpends(tx types.Transaction, ctx types.TransactionV
 }
 
 // ValidateInvalidByDefault returns always an error and can be used to not allow transactions to be validated.
-func ValidateInvalidByDefault(_ types.Transaction, _ types.TransactionValidationContext, _ modules.ConsensusStateGetter) error {
+func ValidateInvalidByDefault(_ modules.ConsensusTransaction, _ types.TransactionValidationContext) error {
 	return errors.New("transaction is invalid as it has been disabled for validation using the ValidateInvalidByDefault function")
 }
 
 // ValidateCoinInputsAreFulfilled validates that all coin outputs are validated
-func ValidateCoinInputsAreFulfilled(tx types.Transaction, ctx types.TransactionValidationContext, css modules.ConsensusStateGetter) error {
+func ValidateCoinInputsAreFulfilled(tx modules.ConsensusTransaction, ctx types.TransactionValidationContext) error {
 	var (
-		err error
-		co  types.CoinOutput
+		ok bool
+		co types.CoinOutput
 	)
 	for index, ci := range tx.CoinInputs {
-		co, err = css.UnspentCoinOutputGet(ci.ParentID)
-		if err != nil {
+		co, ok = tx.SpentCoinOutputs[ci.ParentID]
+		if !ok {
 			return fmt.Errorf(
-				"unable to find parent ID %s as an unspent coin output in the current consensus state at block height %d",
+				"unable to find parent ID %s as an unspent coin output in the current consensus transaction at block height %d",
 				ci.ParentID.String(), ctx.BlockHeight)
 		}
 		// check if the referenced output's condition has been fulfilled
-		err = co.Condition.Fulfill(ci.Fulfillment, types.FulfillContext{
+		err := co.Condition.Fulfill(ci.Fulfillment, types.FulfillContext{
 			ExtraObjects: []interface{}{uint64(index)},
 			BlockHeight:  ctx.BlockHeight,
 			BlockTime:    ctx.BlockTime,
-			Transaction:  tx,
+			Transaction:  tx.Transaction,
 		})
 		if err != nil {
 			return err
@@ -228,14 +228,14 @@ func ValidateCoinInputsAreFulfilled(tx types.Transaction, ctx types.TransactionV
 
 // ValidateCoinOutputsAreBalanced is a validator function that checks if the sum of
 // all types of coin outputs equals the sum of coin inputs.
-func ValidateCoinOutputsAreBalanced(tx types.Transaction, ctx types.TransactionValidationContext, css modules.ConsensusStateGetter) error {
+func ValidateCoinOutputsAreBalanced(tx modules.ConsensusTransaction, ctx types.TransactionValidationContext) error {
 	// collect the coin input sum
 	var coinInputSum types.Currency
 	for _, ci := range tx.CoinInputs {
-		co, err := css.UnspentCoinOutputGet(ci.ParentID)
-		if err != nil {
+		co, ok := tx.SpentCoinOutputs[ci.ParentID]
+		if !ok {
 			return fmt.Errorf(
-				"unable to find parent ID %s as an unspent coin output in the current consensus state at block height %d",
+				"unable to find parent ID %s as an unspent coin output in the current consensus transaction at block height %d",
 				ci.ParentID.String(), ctx.BlockHeight)
 		}
 		coinInputSum = coinInputSum.Add(co.Value)
@@ -260,16 +260,17 @@ func ValidateCoinOutputsAreBalanced(tx types.Transaction, ctx types.TransactionV
 }
 
 // ValidateBlockStakeInputsAreFulfilled validates that all block stake inputs are fulfilled
-func ValidateBlockStakeInputsAreFulfilled(tx types.Transaction, ctx types.TransactionValidationContext, css modules.ConsensusStateGetter) error {
+func ValidateBlockStakeInputsAreFulfilled(tx modules.ConsensusTransaction, ctx types.TransactionValidationContext) error {
 	var (
+		ok  bool
 		err error
 		bso types.BlockStakeOutput
 	)
 	for index, bsi := range tx.BlockStakeInputs {
-		bso, err = css.UnspentBlockStakeOutputGet(bsi.ParentID)
-		if err != nil {
+		bso, ok = tx.SpentBlockStakeOutputs[bsi.ParentID]
+		if !ok {
 			return fmt.Errorf(
-				"unable to find parent ID %s as an unspent block stake output in the current consensus state at block height %d",
+				"unable to find parent ID %s as an unspent blockstake output in the current consensus transaction at block height %d",
 				bsi.ParentID.String(), ctx.BlockHeight)
 		}
 		// check if the referenced output's condition has been fulfilled
@@ -277,7 +278,7 @@ func ValidateBlockStakeInputsAreFulfilled(tx types.Transaction, ctx types.Transa
 			ExtraObjects: []interface{}{uint64(index)},
 			BlockHeight:  ctx.BlockHeight,
 			BlockTime:    ctx.BlockTime,
-			Transaction:  tx,
+			Transaction:  tx.Transaction,
 		})
 		if err != nil {
 			return err
@@ -288,14 +289,14 @@ func ValidateBlockStakeInputsAreFulfilled(tx types.Transaction, ctx types.Transa
 
 // ValidateBlockStakeOutputsAreBalanced is a validator function that checks if the sum of
 // all block stakes outputs equals the sum of all block stake inputs.
-func ValidateBlockStakeOutputsAreBalanced(tx types.Transaction, ctx types.TransactionValidationContext, css modules.ConsensusStateGetter) error {
+func ValidateBlockStakeOutputsAreBalanced(tx modules.ConsensusTransaction, ctx types.TransactionValidationContext) error {
 	// collect the block stake input sum
 	var blockStakeInputSum types.Currency
 	for _, bsi := range tx.BlockStakeInputs {
-		bso, err := css.UnspentBlockStakeOutputGet(bsi.ParentID)
-		if err != nil {
+		bso, ok := tx.SpentBlockStakeOutputs[bsi.ParentID]
+		if !ok {
 			return fmt.Errorf(
-				"unable to find parent ID %s as an unspent block stake output in the current consensus state at block height %d",
+				"unable to find parent ID %s as an unspent blockstake output in the current consensus transaction at block height %d",
 				bsi.ParentID.String(), ctx.BlockHeight)
 		}
 		blockStakeInputSum = blockStakeInputSum.Add(bso.Value)

--- a/modules/consensus/validtransaction.go
+++ b/modules/consensus/validtransaction.go
@@ -2,55 +2,16 @@ package consensus
 
 import (
 	"errors"
+	"fmt"
 
 	bolt "github.com/rivine/bbolt"
 	"github.com/threefoldtech/rivine/modules"
 	"github.com/threefoldtech/rivine/types"
 )
 
-type consensusStateGetter struct {
-	tx *bolt.Tx
-}
-
-func newConsensusStateGetter(tx *bolt.Tx) *consensusStateGetter {
-	return &consensusStateGetter{tx: tx}
-}
-
-var _ modules.ConsensusStateGetter = (*consensusStateGetter)(nil)
-
-func (csg *consensusStateGetter) BlockAtID(id types.BlockID) (modules.ConsensusBlock, error) {
-	pb, err := getBlockMap(csg.tx, id)
-	if err != nil {
-		return modules.ConsensusBlock{}, err
-	}
-	return modules.ConsensusBlock{
-		Block:       pb.Block,
-		Height:      pb.Height,
-		Depth:       pb.Depth,
-		ChildTarget: pb.ChildTarget,
-	}, nil
-}
-
-func (csg *consensusStateGetter) BlockAtHeight(height types.BlockHeight) (modules.ConsensusBlock, error) {
-	id, err := getPath(csg.tx, height)
-	if err != nil {
-		return modules.ConsensusBlock{}, err
-	}
-	return csg.BlockAtID(id)
-}
-
-func (csg *consensusStateGetter) UnspentCoinOutputGet(id types.CoinOutputID) (types.CoinOutput, error) {
-	return getCoinOutput(csg.tx, id)
-}
-
-func (csg *consensusStateGetter) UnspentBlockStakeOutputGet(id types.BlockStakeOutputID) (types.BlockStakeOutput, error) {
-	return getBlockStakeOutput(csg.tx, id)
-}
-
 // validTransaction checks that all fields are valid within the current
 // consensus state. If not an error is returned.
-func (cs *ConsensusSet) validTransaction(tx *bolt.Tx, t types.Transaction, constants types.TransactionValidationConstants, blockHeight types.BlockHeight, blockTimestamp types.Timestamp, isBlockCreatingTx bool) error {
-	csg := newConsensusStateGetter(tx)
+func (cs *ConsensusSet) validTransaction(tx *bolt.Tx, t modules.ConsensusTransaction, constants types.TransactionValidationConstants, blockHeight types.BlockHeight, blockTimestamp types.Timestamp, isBlockCreatingTx bool) error {
 	ctx := types.TransactionValidationContext{
 		ValidationContext: types.ValidationContext{
 			Confirmed:         true,
@@ -69,7 +30,7 @@ func (cs *ConsensusSet) validTransaction(tx *bolt.Tx, t types.Transaction, const
 	// check if we have stand alone validators specific for this tx version, if so apply them
 	if validators, ok := cs.txVersionMappedValidators[t.Version]; ok {
 		for _, validator := range validators {
-			err = validator(t, ctx, csg)
+			err = validator(t, ctx)
 			if err != nil {
 				return err
 			}
@@ -78,14 +39,14 @@ func (cs *ConsensusSet) validTransaction(tx *bolt.Tx, t types.Transaction, const
 
 	// validate all transactions using the stand alone validators
 	for _, validator := range cs.txValidators {
-		err = validator(t, ctx, csg)
+		err = validator(t, ctx)
 		if err != nil {
 			return err
 		}
 	}
 
 	// validate using the plugins, both version-specific as well as global
-	return cs.validateTransactionUsingPlugins(t, ctx, csg, tx)
+	return cs.validateTransactionUsingPlugins(t, ctx, tx)
 }
 
 // TryTransactionSet applies the input transactions to the consensus set to
@@ -120,12 +81,49 @@ func (cs *ConsensusSet) TryTransactionSet(txns []types.Transaction) (modules.Con
 		if err != nil {
 			return err
 		}
+
+		spentCoinOutputs := make(map[types.CoinOutputID]types.CoinOutput)
+		spentBlockStakeOutputs := make(map[types.BlockStakeOutputID]types.BlockStakeOutput)
 		for _, txn := range txns {
+			for _, ci := range txn.CoinInputs {
+				spentCoinOutputs[ci.ParentID], err = getCoinOutput(tx, ci.ParentID)
+				if err != nil {
+					return fmt.Errorf("failed to find coin input %s as unspent coin output in current consensus state: %v", ci.ParentID.String(), err)
+				}
+			}
+			for _, bsi := range txn.BlockStakeInputs {
+				spentBlockStakeOutputs[bsi.ParentID], err = getBlockStakeOutput(tx, bsi.ParentID)
+				if err != nil {
+					return fmt.Errorf("failed to find block stake input %s as unspent block stake output in current consensus state: %v", bsi.ParentID.String(), err)
+				}
+			}
+		}
+
+		var ok bool
+		for _, txn := range txns {
+			cTxn := modules.ConsensusTransaction{
+				Transaction:            txn,
+				SpentCoinOutputs:       make(map[types.CoinOutputID]types.CoinOutput),
+				SpentBlockStakeOutputs: make(map[types.BlockStakeOutputID]types.BlockStakeOutput),
+			}
+			for _, ci := range txn.CoinInputs {
+				cTxn.SpentCoinOutputs[ci.ParentID], ok = spentCoinOutputs[ci.ParentID]
+				if !ok {
+					return fmt.Errorf("failed to find coin input %s from txn %s as unspent coin output in the block map", ci.ParentID.String(), txn.ID().String())
+				}
+			}
+			for _, bsi := range txn.BlockStakeInputs {
+				cTxn.SpentBlockStakeOutputs[bsi.ParentID], ok = spentBlockStakeOutputs[bsi.ParentID]
+				if !ok {
+					return fmt.Errorf("failed to find block stake input %s from txn %s as unspent block stake output in the block map", bsi.ParentID.String(), txn.ID().String())
+				}
+			}
+
 			// a transaction can only be "block creating" in the context of a block,
 			// which we don't have here, so just pass in false for the "isBlockCreatingTx"
 			// argument. In other words, a block creating transaction can never be part
 			// of a transaction pool and must be inserted when the block is actually created
-			err := cs.validTransaction(tx, txn, types.TransactionValidationConstants{
+			err := cs.validTransaction(tx, cTxn, types.TransactionValidationConstants{
 				BlockSizeLimit:         cs.chainCts.BlockSizeLimit,
 				ArbitraryDataSizeLimit: cs.chainCts.ArbitraryDataSizeLimit,
 				MinimumMinerFee:        cs.chainCts.MinimumTransactionFee,
@@ -139,7 +137,7 @@ func (cs *ConsensusSet) TryTransactionSet(txns []types.Transaction) (modules.Con
 			// apply transaction for all plugins
 			for name, plugin := range cs.plugins {
 				bucket := cs.bucketForPlugin(tx, name)
-				err := plugin.ApplyTransaction(txn, diffHolder.Block, diffHolder.Height, bucket)
+				err := plugin.ApplyTransaction(cTxn, diffHolder.Height, bucket)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
remove consensusStateGetter, no longer required,
and use a special ConsensusBlock/Transaction that contains also
the coin outputs and blockstake outputs used as inputs