### PR TITLE
Improve stake modifier calculation

### DIFF
--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -147,6 +147,8 @@ func (cs *ConsensusSet) addBlockToTree(b types.Block) (ce changeEntry, err error
 		// set to indicate that modules.ErrNonExtending should be returned.
 		nonExtending = !newNode.heavierThan(
 			currentNode, cs.chainCts.RootDepth)
+		// At this point the block is added in the cs, so update the header cache
+		cs.knownParentIDs[b.ID()] = b.ParentID
 		if nonExtending {
 			return nil
 		}

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -86,6 +86,12 @@ type ConsensusSet struct {
 	// the genesis block, meaning the PoW is not very expensive.
 	dosBlocks map[types.BlockID]struct{}
 
+	// knownParentIDs keeps track of block ID's and their associated parent ID's.
+	// This allows us to find a parent block of any block, regardless whether or
+	// not it is in the active fork, without having to load all these blocks from
+	// disk and decode them.
+	knownParentIDs map[types.BlockID]types.BlockID
+
 	// checkingConsistency is a bool indicating whether or not a consistency
 	// check is in progress. The consistency check logic call itself, resulting
 	// in infinite loops. This bool prevents that while still allowing for full
@@ -146,6 +152,8 @@ func New(gateway modules.Gateway, bootstrap bool, persistDir string, bcInfo type
 		txValidators:              StandardTransactionValidators(),
 
 		dosBlocks: make(map[types.BlockID]struct{}),
+
+		knownParentIDs: make(map[types.BlockID]types.BlockID),
 
 		bootstrap: bootstrap,
 
@@ -313,22 +321,86 @@ func (cs *ConsensusSet) BlockHeightOfBlock(block types.Block) (height types.Bloc
 func (cs *ConsensusSet) FindParentBlock(b types.Block, depth types.BlockHeight) (block types.Block, exists bool) {
 	var parent *processedBlock
 	var err error
+	var ph types.BlockID
+
+	// subtract one from depth as we start at the parent ID already, not the
+	// current block ID
+	ph, exists = cs.FindParentHash(b.Header().ParentID, depth-1)
+	if !exists {
+		return
+	}
+
 	_ = cs.db.View(func(tx *bolt.Tx) error {
-		pID := b.Header().ParentID
-		// count back to the right block
-		for i := depth; i > 0; i-- {
-			parent, err = getBlockMap(tx, pID)
-			if err != nil {
-				return err
-			}
-			pID = parent.Block.Header().ParentID
+		parent, err = getBlockMap(tx, ph)
+		if err != nil {
+			return err
 		}
+
 		return nil
 	})
+
 	if parent != nil {
 		exists = true
 		block = parent.Block
 	}
+
+	return
+}
+
+// FindParentHash starts at a given hash h, and traversers the chain for the given
+// depth to aquire the hash (block ID) of a block. The caller must ensure that
+// the block with ID `h` is already present in the consensus DB, else this function
+// will fail. Specifically, when this function is used for validation, the parent ID
+// of the block being validated should be used, and depth adjusted accordingly
+func (cs *ConsensusSet) FindParentHash(h types.BlockID, depth types.BlockHeight) (id types.BlockID, exists bool) {
+	var parent *processedBlock
+	var err error
+
+	// Keep track of the current block ID
+	cbID := h
+	// Keep track of the parent ID of the current block
+	// This variable will fix itself in the first loop iteration
+	pID := h
+
+	err = cs.db.View(func(tx *bolt.Tx) error {
+
+		// Count back to the right block, add 1 loop iteration to fix the parent
+		// ID not being present yet.
+		// After the first iteration, current block ID will still be the same,
+		// but parentID will be set to the correctly
+		for i := depth + 1; i > 0; i-- {
+			// We load a new block, therefore the parent ID is now the current ID
+			cbID = pID
+
+			// Update the parent ID, first fetch from the cache
+			pID, exists = cs.knownParentIDs[pID]
+			if !exists {
+				// Not found in cache, load from disk
+				// we previously updted cbID to point to the parent, so we can use it
+				// here instead of the now invalid pID
+				parent, err = getBlockMap(tx, cbID)
+				if err != nil {
+					return err
+				}
+				// save parentID for later use
+				cs.knownParentIDs[cbID] = parent.Block.Header().ParentID
+
+				pID = parent.Block.Header().ParentID
+			}
+
+			// If we get here pID is once again valid
+		}
+
+		return nil
+	})
+
+	if err == nil {
+		exists = true
+		// pID keeps track of the next block ID we need for the loop, so the one
+		// we are interested in is actually in cbID
+		id = cbID
+	}
+
 	return
 }
 

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -347,8 +347,8 @@ func (cs *ConsensusSet) FindParentBlock(b types.Block, depth types.BlockHeight) 
 	return
 }
 
-// FindParentHash starts at a given hash h, and traversers the chain for the given
-// depth to aquire the hash (block ID) of a block. The caller must ensure that
+// FindParentHash starts at a given hash h, and traverse the chain for the given
+// depth to acquire the hash (block ID) of a block. The caller must ensure that
 // the block with ID `h` is already present in the consensus DB, else this function
 // will fail. Specifically, when this function is used for validation, the parent ID
 // of the block being validated should be used, and depth adjusted accordingly
@@ -376,16 +376,17 @@ func (cs *ConsensusSet) FindParentHash(h types.BlockID, depth types.BlockHeight)
 			pID, exists = cs.knownParentIDs[pID]
 			if !exists {
 				// Not found in cache, load from disk
-				// we previously updted cbID to point to the parent, so we can use it
+				// we previously updated cbID to point to the parent, so we can use it
 				// here instead of the now invalid pID
 				parent, err = getBlockMap(tx, cbID)
 				if err != nil {
 					return err
 				}
-				// save parentID for later use
-				cs.knownParentIDs[cbID] = parent.Block.Header().ParentID
 
+				// save parentID for later use
 				pID = parent.Block.Header().ParentID
+				cs.knownParentIDs[cbID] = pID
+
 			}
 
 			// If we get here pID is once again valid

--- a/modules/consensus/proofofblockstake.go
+++ b/modules/consensus/proofofblockstake.go
@@ -20,7 +20,7 @@ import (
 func (cs *ConsensusSet) CalculateStakeModifier(height types.BlockHeight, block types.Block, delay types.BlockHeight) *big.Int {
 	//TODO: check if a new Stakemodifier needs to be calculated. The stakemodifier
 	// only change when a new block is created, and this calculation is also needed
-	// to validate an incomming new block
+	// to validate an incoming new block
 
 	// make a signed version of the current height because sub genesis block is
 	// possible here.
@@ -34,10 +34,11 @@ func (cs *ConsensusSet) CalculateStakeModifier(height types.BlockHeight, block t
 
 	// Rollback the required amount of blocks, minus 1. This way we end up at the direct child of the
 	// block we use to calculate the stakemodifer, rather than the actual first block. Simplifies
-	// the main loop a bit
-	// block is not present in the DB yet so use the parent ID to count back from
-	// subtrackt an aditional block from the delay since we start at the parent ID,
-	// not the current block ID (so we already went back a block)
+	// the main loop a bit.
+	// If we are validating a new block, `block` is not present in the database yet.
+	// To work around this problem, start traversing back from the parent ID of the
+	// given block. Since this means we already traversed one block manually, we
+	// need to subtract 1 from the amount of blocks we need to roll back as well.
 	// Giving both of the above, roll back delay - 2
 	hash, _ := cs.FindParentHash(block.Header().ParentID, (delay-1)-1)
 


### PR DESCRIPTION
Cache the block id's and their matching parent block id's. This removes
about 2256 (in default configuration) database reads, which would read
an entire block every time, possibly loading more than a gigabyte
of data over and over again. This lazy loading removes the need to do
that, apart from the first block which will need to populate the cache.

In case a new daemon is started without any blocks, there will actually
be no database reads to calculate the stake modifier at all until the
daemon is stopped and restarted.