### PR TITLE
add test-related Makefile targets back

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,36 @@ install-std:
 ineffassign:
 	ineffassign $(testpkgs)
 
+test:
+	go test -short -tags='debug testing' -timeout=30s $(testpkgs) -run=$(run)
+test-v:
+	go test -race -v -short -tags='debug testing' -timeout=60s $(testpkgs) -run=$(run)
+test-long: fmt vet
+	go test -v -race -tags='debug testing' -timeout=1000s $(testpkgs) -run=$(run)
+bench: fmt
+	go test -tags='testing' -timeout=1000s -run=XXX -bench=. $(testpkgs)
+cover:
+	@mkdir -p cover/modules
+	@for package in $(testpkgs); do \
+		go test -tags='testing debug' -timeout=1000s -covermode=atomic -coverprofile=cover/$$package.out ./$$package \
+		&& go tool cover -html=cover/$$package.out -o=cover/$$package.html \
+		&& rm cover/$$package.out ; \
+	done
+cover-integration:
+	@mkdir -p cover/modules
+	@for package in $(testpkgs); do \
+		go test -run=TestIntegration -tags='testing debug' -timeout=1000s -covermode=atomic -coverprofile=cover/$$package.out ./$$package \
+		&& go tool cover -html=cover/$$package.out -o=cover/$$package.html \
+		&& rm cover/$$package.out ; \
+	done
+cover-unit:
+	@mkdir -p cover/modules
+	@for package in $(testpkgs); do \
+		go test -run=TestUnit -tags='testing debug' -timeout=1000s -covermode=atomic -coverprofile=cover/$$package.out ./$$package \
+		&& go tool cover -html=cover/$$package.out -o=cover/$$package.html \
+		&& rm cover/$$package.out ; \
+	done
+
 ensure_deps:
 	dep ensure -v
 

--- a/persist/persist_test.go
+++ b/persist/persist_test.go
@@ -1,13 +1,10 @@
 package persist
 
 import (
-	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/NebulousLabs/fastrand"
 	"github.com/threefoldtech/rivine/build"
 )
 
@@ -27,112 +24,5 @@ func TestIntegrationRandomSuffix(t *testing.T) {
 			t.Fatal(err)
 		}
 		file.Close()
-	}
-}
-
-// TestAbsolutePathSafeFile tests creating and committing safe files with
-// absolute paths.
-func TestAbsolutePathSafeFile(t *testing.T) {
-	tmpDir := build.TempDir(persistDir, t.Name())
-	err := os.MkdirAll(tmpDir, 0700)
-	if err != nil {
-		t.Fatal(err)
-	}
-	absPath := filepath.Join(tmpDir, "test")
-
-	// Create safe file.
-	sf, err := NewSafeFile(absPath)
-	defer sf.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Check that the name of the file is not equal to the final name of the
-	// file.
-	if sf.Name() == absPath {
-		t.Errorf("safeFile created with filename: %s has temporary filename that is equivalent to finalName: %s\n", absPath, sf.Name())
-	}
-
-	// Write random data to the file and commit.
-	data := fastrand.Bytes(10)
-	_, err = sf.Write(data)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = sf.CommitSync()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Check that the file exists and has same data that was written to it.
-	dataRead, err := ioutil.ReadFile(absPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(data, dataRead) {
-		t.Fatalf("Committed file has different data than was written to it: expected %v, got %v\n", data, dataRead)
-	}
-}
-
-// TestRelativePathSafeFile tests creating and committing safe files with
-// relative paths. Specifically, we test that calling os.Chdir between creating
-// and committing a safe file doesn't affect the safe file's final path. The
-// relative path tested is relative to the working directory.
-func TestRelativePathSafeFile(t *testing.T) {
-	tmpDir := build.TempDir(persistDir, t.Name())
-	err := os.MkdirAll(tmpDir, 0700)
-	if err != nil {
-		t.Fatal(err)
-	}
-	absPath := filepath.Join(tmpDir, "test")
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	relPath, err := filepath.Rel(wd, absPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Create safe file.
-	sf, err := NewSafeFile(relPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer sf.Close()
-
-	// Check that the path of the file is not equal to the final path of the
-	// file.
-	if sf.Name() == absPath {
-		t.Errorf("safeFile created with filename: %s has temporary filename that is equivalent to finalName: %s\n", absPath, sf.Name())
-	}
-
-	// Write random data to the file.
-	data := fastrand.Bytes(10)
-	_, err = sf.Write(data)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Change directories and commit.
-	tmpChdir := build.TempDir(persistDir, t.Name()+"2")
-	err = os.MkdirAll(tmpChdir, 0700)
-	if err != nil {
-		t.Fatal(err)
-	}
-	os.Chdir(tmpChdir)
-	defer os.Chdir(wd)
-	err = sf.CommitSync()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Check that the file exists and has same data that was written to it.
-	dataRead, err := ioutil.ReadFile(absPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(data, dataRead) {
-		t.Fatalf("Committed file has different data than was written to it: expected %v, got %v\n", data, dataRead)
 	}
 }


### PR DESCRIPTION
also removed two unit tests from the persistent pkg,
one of the two tests failed, while fixing I realized
that the code it was testing was only used in these
two tests, hence deleting it all seemed like the more
economical decision

fixes #623