### PR TITLE
fixes travis build on example/rivchain job, #630

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,12 @@ PARALLEL=1
 
 version = $(shell git describe | cut -d '-' -f 1)
 commit = $(shell git rev-parse --short HEAD)
-ifeq ($(commit), $(shell git rev-list -n 1 $(version) | cut -c1-8))
-fullversion = $(version)
-else
+# if the git describe fails, set the version.
+ifeq ($(version),)
+version = v0.1-$(commit)
+endif
+
+ifneq ($(commit), $(shell git rev-list -n 1 $(version) | cut -c1-7))
 fullversion = $(version)-$(commit)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test:
 test-v:
 	go test -race -v -short -tags='debug testing' -parallel=$(PARALLEL) -timeout=60s $(testpkgs) -run=$(run)
 test-long: fmt vet
-	go test -v -race -tags='debug testing' -parallel=$(PARALLEL) -timeout=1000s $(testpkgs) -run=$(run)
+	go test -v -race -tags='debug testing' -parallel=$(PARALLEL) -timeout=1000s $(testpkgs)
 bench: fmt
 	go test -tags='testing' -timeout=1000s -run=XXX -bench=. $(testpkgs)
 cover:


### PR DESCRIPTION
if git describe fails we fall back on version : `v0.1-{commitHash}`