### PR TITLE
fixes bug in authcoin status of an address

### DIFF
--- a/extensions/authcointx/csplugin.go
+++ b/extensions/authcointx/csplugin.go
@@ -556,6 +556,9 @@ func (p *Plugin) getAuthAddressStateFromBucketAt(authAddressBucket *bolt.Bucket,
 		return false, err
 	}
 	if b == nil {
+		if p.reverse {
+			return true, nil
+		}
 		return false, nil
 	}
 	var state bool
@@ -593,6 +596,9 @@ func (p *Plugin) getAuthAddressStateFromBucket(authAddressBucket *bolt.Bucket, u
 		return false, err
 	}
 	if b == nil {
+		if p.reverse {
+			return true, nil
+		}
 		return false, nil
 	}
 	var state bool


### PR DESCRIPTION
This fixes a bug where the information about an address, if it does not exist in our bucket is not reversed properly.